### PR TITLE
Turn file references in README into links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A bot that checks for signatures in PRs and merges them if they're good.
 Installation
 ============
 
-Populate config.sample.yml with your GitHub credentials. This program is not meant to be run as a daemon, but rather as an event handler for GitHub hooks.
+Populate [config.sample.yaml](config.sample.yaml) with your GitHub credentials. This program is not meant to be run as a daemon, but rather as an event handler for GitHub hooks.
 
 License
 =======
 
-MIT, see LICENSE.md
+MIT, see [LICENSE](LICENSE.md)


### PR DESCRIPTION
The links can be clicked in GitHub to go straight to the referenced file.
